### PR TITLE
0.3

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,10 +8,10 @@
             "name": "Python: Run miracron",
             "type": "python",
             "request": "launch",
-            "program": "miracron.py",
+            "program": "miracron/miracron.py",
             "args": [
                 "--config",
-                "./docker/config.yml"
+                "config.yml"
             ],
             "env": {
                 "MIRACRON_LOG": "INFO"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       # 録画スケジュールを再生成するスケジュール(cron書式) (デフォルト: 毎日の午前5時)
       MIRACRON_UPDATE_SCHEDULE: "0 5 * * *"
       # ログを出力するレベル(CRITICAL, ERROR, WARNING, INFO, DEBUG のいずれか) (デフォルト: WARNING)
-      MIRACRON_LOG: INFO
+      MIRACRON_LOGLEVEL: INFO
       # コンフィグファイルのコンテナ内のパス(デフォルト: /etc/miracron/config.yml)
       MIRACRON_CONFIG: /etc/miracron/config.yml
     init: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       MIRACRON_LOGLEVEL: INFO
       # コンフィグファイルのコンテナ内のパス(デフォルト: /etc/miracron/config.yml)
       MIRACRON_CONFIG: /etc/miracron/config.yml
+      # 閲覧用のcronルールを生成するパス(デフォルト: 生成しない)
+      MIRACRON_CRON_COPY: /var/lib/miracron/recorded/cron_schedule.txt
     init: true
     logging:
       driver: json-file  # お好みでjournaldに変更

--- a/miracron/miracron.py
+++ b/miracron/miracron.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '-l', '--loglevel',
         choices=['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'],
-        default=os.getenv('MIRACRON_LOG', 'WARNING'),
+        default=os.getenv('MIRACRON_LOGLEVEL', 'WARNING'),
         help='the threshold of logging level [env: MIRACRON_LOG] [default: WARNING]'
     )
     parser.add_argument(

--- a/miracron/miracron.py
+++ b/miracron/miracron.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
         '-l', '--loglevel',
         choices=['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'],
         default=os.getenv('MIRACRON_LOGLEVEL', 'WARNING'),
-        help='the threshold of logging level [env: MIRACRON_LOG] [default: WARNING]'
+        help='the threshold of logging level [env: MIRACRON_LOGLEVEL] [default: WARNING]'
     )
     parser.add_argument(
         '-L', '--logfile',

--- a/miracron/miracron.py
+++ b/miracron/miracron.py
@@ -90,6 +90,12 @@ if __name__ == '__main__':
         help='the threshold of logging level [env: MIRACRON_LOG] [default: WARNING]'
     )
     parser.add_argument(
+        '-L', '--logfile',
+        metavar='<logfile>',
+        default=os.getenv('MIRACRON_LOGFILE'),
+        help='path to logfile [default: stdout and stderr]'
+    )
+    parser.add_argument(
         '-o', '--outfile',
         metavar='<outfile>',
         default=os.getenv('MIRACRON_OUTFILE'),
@@ -99,8 +105,18 @@ if __name__ == '__main__':
 
     # ログ設定
     logger = logging.getLogger('miracron')
-    logger.addHandler(logging.StreamHandler(stream = sys.stderr))
     logger.setLevel(args.loglevel.upper())
+    if args.logfile:
+        file_handler = logging.FileHandler(filename = args.logfile)
+        file_handler.setFormatter(logging.Formatter(fmt = '%(asctime)s [%(levelname)s] %(message)s'))
+        logger.addHandler(file_handler)
+    else:
+        stdout_handler = logging.StreamHandler(stream = sys.stdout)
+        stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)
+        logger.addHandler(stdout_handler)
+        stderr_handler = logging.StreamHandler(stream = sys.stderr)
+        stderr_handler.addFilter(lambda record: record.levelno > logging.INFO)
+        logger.addHandler(stderr_handler)
 
     logger.info('Start miracron.')
     logger.debug('Start loading configuration.')

--- a/miracron/miracron.py
+++ b/miracron/miracron.py
@@ -89,6 +89,12 @@ if __name__ == '__main__':
         default=os.getenv('MIRACRON_LOG', 'WARNING'),
         help='the threshold of logging level [env: MIRACRON_LOG] [default: WARNING]'
     )
+    parser.add_argument(
+        '-o', '--outfile',
+        metavar='<outfile>',
+        default=os.getenv('MIRACRON_OUTFILE'),
+        help='path to output cron rules [default: stdout]'
+    )
     args = parser.parse_args()
 
     # ログ設定
@@ -148,7 +154,8 @@ if __name__ == '__main__':
 
     margin_sec = datetime.timedelta(seconds = config['startMarginSec'])
     timezone = datetime.datetime.utcnow().astimezone().tzinfo
-    # cronルールの出力
+    cron_list = []
+    # cronルールの生成
     for program in match_programs:
         start_at = datetime.datetime.fromtimestamp(program['startAt']/1000, timezone)
         start_margin = start_at - margin_sec
@@ -173,8 +180,18 @@ if __name__ == '__main__':
         logger.debug(comment_str)
         logger.debug(cron_str)
         logger.debug('#####')
-        print(comment_str)
-        print(cron_str)
-        print('#####')
+        cron_list.append(comment_str)
+        cron_list.append(cron_str)
+        cron_list.append('#####')
+
+    # cronルールの書き込み
+    if args.outfile:
+        with open(args.outfile, mode='w', encoding='utf-8') as file:
+            for line in cron_list:
+                file.write(line)
+                file.write('\n')
+    else:
+        for line in cron_list:
+            print(line)
 
     logger.info(f"Miracron completed. Scheduled program count: {len(match_programs)}")

--- a/scripts/miracron-update.sh
+++ b/scripts/miracron-update.sh
@@ -7,3 +7,8 @@ python3 /usr/local/lib/miracron/miracron.py --outfile /var/spool/cron/crontabs/r
 echo "${MIRACRON_UPDATE_SCHEDULE:-0 5 * * *} miracron-update.sh" >> /var/spool/cron/crontabs/root
 # cron更新したフラグを作成
 echo 'root' >> /var/spool/cron/crontabs/cron.update
+
+# cronルールを閲覧するためだけのコピーを作る
+if [ -n "${MIRACRON_CRON_COPY-}" ]; then
+    cp /var/spool/cron/crontabs/root "${MIRACRON_CRON_COPY}"
+fi

--- a/scripts/miracron-update.sh
+++ b/scripts/miracron-update.sh
@@ -1,7 +1,9 @@
 #!/bin/ash
 set -eu
 
-unset MIRACRON_RULES
-MIRACRON_RULES="$(python3 /usr/local/lib/miracron/miracron.py)"
-
-(echo "${MIRACRON_UPDATE_SCHEDULE:-0 5 * * *} miracron-update.sh"; echo "$MIRACRON_RULES") | busybox crontab -
+# 録画ルール生成(ファイルは上書きされる)
+python3 /usr/local/lib/miracron/miracron.py --outfile /var/spool/cron/crontabs/root
+# 定期アップデートルールを末尾に追加
+echo "${MIRACRON_UPDATE_SCHEDULE:-0 5 * * *} miracron-update.sh" >> /var/spool/cron/crontabs/root
+# cron更新したフラグを作成
+echo 'root' >> /var/spool/cron/crontabs/cron.update


### PR DESCRIPTION
* デフォルトのログ出力先をINFO以下はstdout、WARNING以上はstderrに分けた
* ファイルへログ出力できるようにした
* ファイルへcronスケジュール出力できるようにした
  * そのcronスケジュールの閲覧用コピーを作れるようにした(Docker側での対応)
* ログレベルを絞り込む環境変数名を変えた
  * MIRACRON_LOG -> MIRACRON_LOGLEVEL